### PR TITLE
Fix: Typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@
 - Then create a Pull Request and wait for review.
 - Pull request title : **`fix: bla bla bla`** , important to pass the checks.
 - Don't forget to attach **`Screenshots, Proper Description and Issue Number`**
-- Remember to be respectful to other contributors, mentors, comunnity
+- Remember to be respectful to other contributors, mentors, community
 - Don't raise invalid/spam issues they will be closed !!
 
 <br/>


### PR DESCRIPTION
# Issue name 📐

- I Ali Fixed a Typo in CONTRIBUTING.md, the typo was in the word "Community". 
- This Pull request doesn't have an open issue. 

[put x to check the boxes]: <> (This is a comment, it will not be included)

## Guidelines 🔐

**I accept the fact that i have followed the guidelines and have not copied the codes from around the internet**

- [x] **Contribution Guidelines**
- [x] **Code of Conduct**

## Screenshots 📷

**Here are the pictures of changes that i have made 🔽**

<attach screenshots here>
  
![image](https://user-images.githubusercontent.com/90851899/188284143-2f2a1cce-0f56-45cf-bfa3-845f8fa1756e.png)

  
  
---
