### PR TITLE
fix: Cleaning/Format of CSS code that was breaking build

### DIFF
--- a/client/src/styles/OxygenSupplier.css
+++ b/client/src/styles/OxygenSupplier.css
@@ -1,10 +1,10 @@
 /* CSS Styles for Oxygen Supplier Page, Components, Data */
 
-@import url('https://fonts.googleapis.com/css?family=Alatsi');
-@import url('https://fonts.googleapis.com/css?family=Montserrat');
+@import url("https://fonts.googleapis.com/css?family=Alatsi");
+@import url("https://fonts.googleapis.com/css?family=Montserrat");
 
 body {
-  font-family: 'Montserrat';
+  font-family: "Montserrat";
   margin: auto;
 }
 
@@ -12,8 +12,6 @@ body {
   background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
     url(../assets/images/oxygenSupplierBannerImage.jpg);
   height: 50%;
-  /* text-align: center; */
-  /* margin: auto; */
   padding: 220px 200px 180px 200px;
   display: block;
   background-position: center;
@@ -24,9 +22,7 @@ body {
 }
 
 .searchBar {
-  /* margin-top: 15px; */
   background: white;
-  /* border: 1px solid #0603e6; */
   border-radius: 5px;
   padding: 15px;
   display: flex;
@@ -50,9 +46,8 @@ body {
   transform: translate(-50%, -50%);
   width: 700px;
   font-weight: bold;
-  /* text-shadow: 1px 1px white; */
   letter-spacing: 2px;
-  font-family: 'Montserrat';
+  font-family: "Montserrat";
 }
 
 .loading-container {
@@ -92,10 +87,6 @@ body {
   margin: 0.5rem 0;
 }
 
-/* .oxygenSupplier-container:hover{ 
-	box-shadow: 0px 1px 2px 0px rgba(0,255,255,0.7),
-} */
-
 .info {
   display: flex;
   flex-direction: column;
@@ -108,7 +99,7 @@ body {
 }
 
 .supplier-name {
-  font-family: 'Montserrat';
+  font-family: "Montserrat";
   font-weight: bold;
   color: white;
   font-size: 2.4rem;
@@ -116,7 +107,7 @@ body {
 }
 
 .oxygenSupplier-container .details h5 {
-  font-family: 'Montserrat';
+  font-family: "Montserrat";
   font-weight: 900;
   color: #ffffff;
 }
@@ -148,13 +139,14 @@ body {
 .address h5 {
   padding-right: 5px;
 }
-/* 
-Mobile responsive mode only */
+
+/* Mobile responsive mode only */
+
 @media only screen and (max-width: 768px) {
   .head-container {
     height: 50%;
     padding: 150px 150px 100px 150px;
-	margin-bottom: 25px;
+    margin-bottom: 25px;
   }
   .searchBar {
     width: 350px;


### PR DESCRIPTION
# Issue name 📐

- **I Klaha have worked for 105**

[put x to check the boxes]: <> (This is a comment, it will not be included)

## Guidelines 🔐

**I accept the fact that i have followed the guidelines and have not copied the codes from around the internet**

- [x] **Contribution Guidelines**
- [x] **Code of Conduct**

## Issue to be closed 🛅

- **My pull request closes #105**

## Screenshots 📷

**Here are the pictures of changes that i have made 🔽**

![Screen Shot 2022-09-09 at 21 45 29](https://user-images.githubusercontent.com/5325061/189462579-3f098e3a-eb91-4773-aba1-7747b80bb140.png)

Debugging this was kinda strange. At first thought you would think the issue was something related to a "ToLowercase" method being implemented wrong. But it's been used in just PlasmaDonor.js and works as expected.

I compared the last commit where build was working 3f586e04c6e82ca50cfcece0c53fdd2f56956725 and the one after it where the build broke f597a6d066fc3e6d2cd3833e7baa25ddeb58a301 and began to do some build tests and found that *__strangely__* comments inside CSS selectors where breaking the build.

So, after a bit of formating and clean up; build is working again as it should.

![Screen Shot 2022-09-09 at 21 45 42](https://user-images.githubusercontent.com/5325061/189462821-204f9772-29a3-4af8-acba-5af362c61036.png)
  
---
